### PR TITLE
Fix for issue #1116

### DIFF
--- a/src/main/java/com/infinityraider/agricraft/blocks/irrigation/BlockSprinkler.java
+++ b/src/main/java/com/infinityraider/agricraft/blocks/irrigation/BlockSprinkler.java
@@ -110,7 +110,7 @@ public class BlockSprinkler extends BlockTileCustomRenderedBase<TileEntitySprink
 
     //see if the block can stay
     public boolean canBlockStay(World world, BlockPos pos) {
-        return (world.getBlockState(pos.add(0, 1, 0)).getBlock() instanceof IAgriFluidComponent);
+        return (world.getBlockState(pos.add(0, 1, 0)).getBlock() instanceof BlockWaterChannel);
     }
 
     @Override


### PR DESCRIPTION
The reason why the sprinkler pops out it's because `canBlockStay` is checking the class of the block above for an interface that's used only in tile entities, so it will never be true. I changed to check for `BlockWaterChannel` which is the class checked for in `canPlaceBlockAt`.